### PR TITLE
Fix audio mute icon

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -230,7 +230,7 @@ void syshud::on_change(const char& reason, const int& value) {
 	// Audio output
 	else if (reason == 'o') {
 		if (muted)
-			icon = "audio-volume-muted-blocking-symbolic";
+			icon = "audio-volume-muted-symbolic";
 		else if (value <= 100)
 			icon = "audio-volume-" + value_levels[value / 34 + 1] + "-symbolic";
 		else


### PR DESCRIPTION
Replaces "audio-volume-muted-blocking-symbolic" with "audio-volume-muted-symbolic" to show the correct mute icon when output is muted.