### PR TITLE
Modify the timeout logic

### DIFF
--- a/src/window.hpp
+++ b/src/window.hpp
@@ -32,8 +32,9 @@ class syshud : public Gtk::Window {
 		std::map<std::string, std::map<std::string, std::string>> config_main;
 		bool muted;
 		std::string previous_class;
-		int timeout;
+		float timeout;
 		char last_reason;
+		sigc::connection hide_overlay_connection;
 		sigc::connection timeout_connection;
 		property_animator scale_animator;
 


### PR DESCRIPTION
I encountered some issues when modifying the volume while the overlay was still showing (the first video below). This PR modifies a bit the timeout logic to avoid having multiple calls to `syshud::timer`, instead of checking each second for the timeout we only create a single connection with an interval equal to the timeout, this connection is disconnected and recreated every time `syshud::on_change` is called.
I also made the `timeout` variable a float instead of an int, which allows for fractional timeouts (currently, `timeout=2.8` inside the config will give a 2s timeout). This could also be done by specifying the timeout in milliseconds, but it would break current configs.

With the latest commit:

https://github.com/user-attachments/assets/b48cf828-a71c-4e5f-a3a8-b3994d115989

With the patch:

https://github.com/user-attachments/assets/8d7319e8-04ca-44c9-a2d2-69e3ae45030c



